### PR TITLE
feat: support strict URL-encoded form transport

### DIFF
--- a/fixtures/specifications/urlencoded.yaml
+++ b/fixtures/specifications/urlencoded.yaml
@@ -8,6 +8,14 @@ paths:
   /logout:
     post:
       operationId: logout
+      parameters:
+        - name: Origin
+          in: header
+          required: true
+          schema:
+            type: string
+      security:
+        - Csrf: []
       requestBody:
         required: true
         content:
@@ -26,3 +34,10 @@ paths:
       responses:
         "204":
           description: Logged out
+
+components:
+  securitySchemes:
+    Csrf:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token

--- a/fixtures/specifications/urlencoded.yaml
+++ b/fixtures/specifications/urlencoded.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+
+info:
+  title: URL-encoded form transport
+  version: 0.1.0
+
+paths:
+  /logout:
+    post:
+      operationId: logout
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - csrfToken
+              properties:
+                csrfToken:
+                  type: string
+                  example: a+b c/%
+                returnTo:
+                  type: string
+                  example: /spaces?name=M\u00fcnchen
+      responses:
+        "204":
+          description: Logged out

--- a/package-lock.json
+++ b/package-lock.json
@@ -6344,7 +6344,7 @@
     },
     "packages/npm/skiffa-generator": {
       "name": "@skiffa/generator",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "ISC",
       "dependencies": {
         "@jns42/core": "^0.7.11",
@@ -6379,7 +6379,7 @@
     },
     "packages/npm/skiffa-lib": {
       "name": "@skiffa/lib",
-      "version": "0.14.5",
+      "version": "0.14.6",
       "license": "ISC",
       "dependencies": {
         "@types/node": "^22.15.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6350,7 +6350,7 @@
         "@jns42/core": "^0.7.11",
         "@jns42/generator": "^0.21.16",
         "@skiffa/core": "^0.2.8",
-        "@skiffa/lib": "^0.14.2",
+        "@skiffa/lib": "^0.14.6",
         "@types/node": "^22.15.17",
         "@types/yargs": "^17.0.33",
         "camelcase": "^8.0.0",

--- a/packages/npm/skiffa-generator/package.json
+++ b/packages/npm/skiffa-generator/package.json
@@ -48,7 +48,7 @@
     "@jns42/core": "^0.7.11",
     "@jns42/generator": "^0.21.16",
     "@skiffa/core": "^0.2.8",
-    "@skiffa/lib": "^0.14.2",
+    "@skiffa/lib": "^0.14.6",
     "@types/node": "^22.15.17",
     "@types/yargs": "^17.0.33",
     "camelcase": "^8.0.0",

--- a/packages/npm/skiffa-generator/package.json
+++ b/packages/npm/skiffa-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiffa/generator",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "sideEffects": false,
   "description": "",
   "type": "module",

--- a/packages/npm/skiffa-generator/src/generators/files/client-server-test-ts.ts
+++ b/packages/npm/skiffa-generator/src/generators/files/client-server-test-ts.ts
@@ -330,6 +330,7 @@ function* generateOperationTest(
 
         switch (requestBodyModel.contentType) {
           case "text/plain":
+          case "application/x-www-form-urlencoded":
           case "application/json": {
             const validateFunctionName = getIsBodyFunction(names, requestBodyModel);
             assert(validateFunctionName != null);

--- a/packages/npm/skiffa-generator/src/generators/functions/client-operation.ts
+++ b/packages/npm/skiffa-generator/src/generators/functions/client-operation.ts
@@ -485,7 +485,7 @@ export function* generateClientOperationFunction(
               case "cookie": {
                 yield itt`
                 if(configuration.${getAuthenticationMemberName(authenticationModel)} != null) {
-                  cookieParameters.append(${JSON.stringify(authenticationModel.parameterName)}, configuration.${getAuthenticationMemberName(authenticationModel)});
+                  lib.addParameter(cookieParameters, ${JSON.stringify(authenticationModel.parameterName)}, configuration.${getAuthenticationMemberName(authenticationModel)});
                 }
               `;
                 break;
@@ -553,7 +553,7 @@ export function* generateClientOperationFunction(
         "", "; ", "=",
       );
       if(cookie !== ""){
-        requestHeaders.append("set-cookie", cookie);
+        requestHeaders.append("cookie", cookie);
       }
 
       requestHeaders.append("accept", lib.stringifyAcceptHeader(accept.${operationAcceptConstName}));
@@ -657,6 +657,31 @@ export function* generateClientOperationFunction(
 
           yield itt`
             const stream = lib.serializeTextValue(String(entity));
+            body = await lib.collectStream(stream);
+          `;
+
+          break;
+        }
+
+        case "application/x-www-form-urlencoded": {
+          const isBodyTypeFunction = getIsBodyFunction(names, bodyModel);
+
+          if (isBodyTypeFunction != null) {
+            yield itt`
+              if(configuration.validateOutgoingEntity) {
+                if(!validators.${isBodyTypeFunction}(entity)) {
+                  const lastError = validators.getLastValidationError();
+                  throw new lib.ClientResponseEntityValidationFailed(
+                    lastError.path,
+                    lastError.rule,
+                  );
+                }
+              }
+            `;
+          }
+
+          yield itt`
+            const stream = lib.serializeUrlEncodedForm(entity);
             body = await lib.collectStream(stream);
           `;
 

--- a/packages/npm/skiffa-generator/src/generators/functions/endpoint-handler-method.ts
+++ b/packages/npm/skiffa-generator/src/generators/functions/endpoint-handler-method.ts
@@ -610,6 +610,43 @@ function* generateBody(
         break;
       }
 
+      case "application/x-www-form-urlencoded": {
+        const bodySchemaId = bodyModel.schemaId;
+        const bodyTypeName = bodySchemaId == null ? bodySchemaId : names[bodySchemaId];
+        const isBodyTypeFunction = getIsBodyFunction(names, bodyModel);
+
+        yield itt`
+          try {
+            requestEntity = await lib.deserializeUrlEncodedForm(
+              serverIncomingRequest.stream
+            ) as ${bodyTypeName == null ? "unknown" : `types.${bodyTypeName}`};
+          } catch (error) {
+            if (error instanceof lib.UrlEncodedFormError) {
+              throw new lib.ServerRequestEntityValidationFailed(
+                "",
+                "valid application/x-www-form-urlencoded entity",
+              );
+            }
+            throw error;
+          }
+        `;
+
+        if (isBodyTypeFunction != null) {
+          yield itt`
+            if(validateIncomingEntity) {
+              if(!validators.${isBodyTypeFunction}(requestEntity)) {
+                const lastError = validators.getLastValidationError();
+                throw new lib.ServerRequestEntityValidationFailed(
+                  lastError.path,
+                  lastError.rule,
+                );
+              }
+            }
+          `;
+        }
+        break;
+      }
+
       default: {
         yield itt`
           requestEntity = async function* (signal){

--- a/packages/npm/skiffa-generator/src/generators/functions/endpoint-handler-method.ts
+++ b/packages/npm/skiffa-generator/src/generators/functions/endpoint-handler-method.ts
@@ -216,14 +216,16 @@ function* generateBody(
             if (parseParameterFunction == null) {
               return `
                 ${parameterName}: 
-                lib.first(lib.getParameterValues(pathParameters, ${JSON.stringify(parameterModel.name)})),
+                lib.first(lib.getParameterValues(serverIncomingRequest.headers, ${JSON.stringify(
+                  parameterModel.name.toLowerCase(),
+                )})),
               `;
             }
 
             return `
             ${parameterName}: 
                 parsers.${parseParameterFunction}(lib.getParameterValues(serverIncomingRequest.headers, ${JSON.stringify(
-                  parameterModel.name,
+                  parameterModel.name.toLowerCase(),
                 )})),
             `;
           }),
@@ -424,7 +426,9 @@ function* generateBody(
             case "header": {
               yield itt`
                 ${getAuthenticationMemberName(authenticationModel)}:
-                  lib.first(lib.getParameterValues(serverIncomingRequest.headers, ${JSON.stringify(authenticationModel.parameterName)})),
+                  lib.first(lib.getParameterValues(serverIncomingRequest.headers, ${JSON.stringify(
+                    authenticationModel.parameterName!.toLowerCase(),
+                  )})),
               `;
               break;
             }

--- a/packages/npm/skiffa-generator/src/generators/helpers.ts
+++ b/packages/npm/skiffa-generator/src/generators/helpers.ts
@@ -54,7 +54,9 @@ export function isBodyModelMockable(model: skiffaCore.BodyContainer, mockables: 
   return (
     model.schemaId != null &&
     mockables.has(model.schemaId) &&
-    (model.contentType === "application/json" || model.contentType === "text/plain")
+    (model.contentType === "application/json" ||
+      model.contentType === "application/x-www-form-urlencoded" ||
+      model.contentType === "text/plain")
   );
 }
 

--- a/packages/npm/skiffa-generator/src/integration/urlencoded.test.ts
+++ b/packages/npm/skiffa-generator/src/integration/urlencoded.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import * as lib from "@skiffa/lib";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = path.resolve(dirname, "../../../../..");
+
+test("generated URL-encoded client and server use a strict typed transport", async (context) => {
+  const generatedRoot = path.join(projectRoot, "generated");
+  mkdirSync(generatedRoot, { recursive: true });
+  const packageDirectory = mkdtempSync(path.join(generatedRoot, "urlencoded-test-"));
+  context.after(() => rmSync(packageDirectory, { recursive: true, force: true }));
+
+  execFileSync(
+    process.execPath,
+    [
+      path.join(projectRoot, "packages/npm/skiffa-generator/bundled/program.js"),
+      "package",
+      path.join(projectRoot, "fixtures/specifications/urlencoded.yaml"),
+      "--package-directory",
+      packageDirectory,
+      "--package-name",
+      "urlencoded-test",
+      "--package-version",
+      "0.0.0",
+      "--request-types",
+      "application/x-www-form-urlencoded",
+    ],
+    { cwd: projectRoot },
+  );
+  execFileSync(path.join(projectRoot, "node_modules/.bin/tsc"), ["--project", packageDirectory], {
+    cwd: projectRoot,
+  });
+  const generatedServer = await import(
+    pathToFileURL(path.join(packageDirectory, "transpiled/server.js")).href
+  );
+  const generatedClient = await import(
+    pathToFileURL(path.join(packageDirectory, "transpiled/client.js")).href
+  );
+  const apiServer = new generatedServer.Server({
+    validateIncomingEntity: true,
+  });
+  let handlerCalls = 0;
+  let receivedEntity: unknown;
+  apiServer.registerLogoutOperation(async (entity: unknown) => {
+    handlerCalls++;
+    receivedEntity = entity;
+  });
+  apiServer.registerMiddleware(lib.createErrorMiddleware());
+
+  await using listener = await lib.listen(apiServer, {});
+  const baseUrl = new URL(`http://localhost:${listener.port}`);
+  const url = new URL("/logout", baseUrl);
+
+  await generatedClient.logout(
+    {
+      csrfToken: "a+b c/%",
+      returnTo: "/spaces?name=\u732b",
+    },
+    { baseUrl },
+  );
+  assert.equal(handlerCalls, 1);
+  assert.equal(Object.getPrototypeOf(receivedEntity), null);
+  const receivedForm = receivedEntity as Record<string, string>;
+  assert.equal(receivedForm.csrfToken, "a+b c/%");
+  assert.equal(receivedForm.returnTo, "/spaces?name=\u732b");
+
+  const prototypeResponse = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: "csrfToken=value&__proto__=safe",
+  });
+  assert.equal(prototypeResponse.status, 204);
+  assert.equal(handlerCalls, 2);
+  assert.equal(Object.getPrototypeOf(receivedEntity), null);
+  const prototypeForm = receivedEntity as Record<string, string>;
+  assert.equal(prototypeForm.__proto__, "safe");
+  assert.equal(Object.hasOwn(prototypeForm, "__proto__"), true);
+  assert.equal(({} as Record<string, unknown>).safe, undefined);
+
+  const duplicateResponse = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: "csrfToken=first&csrfToken=second",
+  });
+  assert.equal(duplicateResponse.status, 400);
+  assert.equal(handlerCalls, 2);
+
+  const oversizedResponse = await fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: `csrfToken=${"x".repeat(lib.urlEncodedFormMaximumBytes)}`,
+  });
+  assert.equal(oversizedResponse.status, 400);
+  assert.equal(handlerCalls, 2);
+
+  const wrongMediaTypeResponse = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+    },
+    body: "csrfToken=value",
+  });
+  assert.equal(wrongMediaTypeResponse.status, 415);
+  assert.equal(handlerCalls, 2);
+});

--- a/packages/npm/skiffa-generator/src/integration/urlencoded.test.ts
+++ b/packages/npm/skiffa-generator/src/integration/urlencoded.test.ts
@@ -46,10 +46,19 @@ test("generated URL-encoded client and server use a strict typed transport", asy
   });
   let handlerCalls = 0;
   let receivedEntity: unknown;
-  apiServer.registerLogoutOperation(async (entity: unknown) => {
-    handlerCalls++;
-    receivedEntity = entity;
-  });
+  let receivedParameters: unknown;
+  let receivedAuthentication: unknown;
+  apiServer.registerCsrfAuthentication(async (credential: string) =>
+    credential === "csrf-value" ? { credential } : undefined,
+  );
+  apiServer.registerLogoutOperation(
+    async (parameters: unknown, entity: unknown, authentication: unknown) => {
+      handlerCalls++;
+      receivedParameters = parameters;
+      receivedEntity = entity;
+      receivedAuthentication = authentication;
+    },
+  );
   apiServer.registerMiddleware(lib.createErrorMiddleware());
 
   await using listener = await lib.listen(apiServer, {});
@@ -57,13 +66,16 @@ test("generated URL-encoded client and server use a strict typed transport", asy
   const url = new URL("/logout", baseUrl);
 
   await generatedClient.logout(
+    { origin: "https://app.example" },
     {
       csrfToken: "a+b c/%",
       returnTo: "/spaces?name=\u732b",
     },
-    { baseUrl },
+    { baseUrl, csrf: "csrf-value" },
   );
   assert.equal(handlerCalls, 1);
+  assert.deepEqual(receivedParameters, { origin: "https://app.example" });
+  assert.deepEqual(receivedAuthentication, { csrf: { credential: "csrf-value" } });
   assert.equal(Object.getPrototypeOf(receivedEntity), null);
   const receivedForm = receivedEntity as Record<string, string>;
   assert.equal(receivedForm.csrfToken, "a+b c/%");
@@ -71,7 +83,11 @@ test("generated URL-encoded client and server use a strict typed transport", asy
 
   const prototypeResponse = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      origin: "https://app.example",
+      "x-csrf-token": "csrf-value",
+    },
     body: "csrfToken=value&__proto__=safe",
   });
   assert.equal(prototypeResponse.status, 204);
@@ -84,7 +100,11 @@ test("generated URL-encoded client and server use a strict typed transport", asy
 
   const duplicateResponse = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      origin: "https://app.example",
+      "x-csrf-token": "csrf-value",
+    },
     body: "csrfToken=first&csrfToken=second",
   });
   assert.equal(duplicateResponse.status, 400);
@@ -92,7 +112,11 @@ test("generated URL-encoded client and server use a strict typed transport", asy
 
   const oversizedResponse = await fetch(url, {
     method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
+    headers: {
+      "content-type": "application/x-www-form-urlencoded",
+      origin: "https://app.example",
+      "x-csrf-token": "csrf-value",
+    },
     body: `csrfToken=${"x".repeat(lib.urlEncodedFormMaximumBytes)}`,
   });
   assert.equal(oversizedResponse.status, 400);
@@ -102,6 +126,8 @@ test("generated URL-encoded client and server use a strict typed transport", asy
     method: "POST",
     headers: {
       "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+      origin: "https://app.example",
+      "x-csrf-token": "csrf-value",
     },
     body: "csrfToken=value",
   });

--- a/packages/npm/skiffa-lib/package.json
+++ b/packages/npm/skiffa-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skiffa/lib",
-  "version": "0.14.5",
+  "version": "0.14.6",
   "description": "",
   "type": "module",
   "module": "./bundles/main.js",

--- a/packages/npm/skiffa-lib/src/serialization.ts
+++ b/packages/npm/skiffa-lib/src/serialization.ts
@@ -1,3 +1,4 @@
 export * from "./serialization/json.js";
 export * from "./serialization/ndjson.js";
 export * from "./serialization/text.js";
+export * from "./serialization/urlencoded.js";

--- a/packages/npm/skiffa-lib/src/serialization/urlencoded.test.ts
+++ b/packages/npm/skiffa-lib/src/serialization/urlencoded.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  UrlEncodedFormError,
+  deserializeUrlEncodedForm,
+  serializeUrlEncodedForm,
+  urlEncodedFormMaximumBytes,
+  urlEncodedFormMaximumFields,
+} from "./urlencoded.js";
+
+test("round trips scalar fields with form percent and plus encoding", async () => {
+  const body = await collect(
+    serializeUrlEncodedForm({
+      csrfToken: "a+b c/%",
+      returnTo: "/spaces?name=\u732b",
+      enabled: true,
+      count: 2,
+      omitted: undefined,
+    }),
+  );
+
+  assert.equal(
+    new TextDecoder().decode(body),
+    // cspell:disable-next-line
+    "csrfToken=a%2Bb+c%2F%25&returnTo=%2Fspaces%3Fname%3D%E7%8C%AB&enabled=true&count=2",
+  );
+  const result = await deserializeUrlEncodedForm(asStream(body));
+  assert.equal(Object.getPrototypeOf(result), null);
+  assert.deepEqual(
+    { ...result },
+    {
+      csrfToken: "a+b c/%",
+      returnTo: "/spaces?name=\u732b",
+      enabled: "true",
+      count: "2",
+    },
+  );
+});
+
+test("rejects duplicate singleton fields", async () => {
+  await assert.rejects(
+    deserializeUrlEncodedForm(asStream("csrfToken=first&csrfToken=second")),
+    UrlEncodedFormError,
+  );
+});
+
+test("rejects malformed percent encoding and encoded invalid UTF-8", async () => {
+  await assert.rejects(deserializeUrlEncodedForm(asStream("value=%")), UrlEncodedFormError);
+  await assert.rejects(deserializeUrlEncodedForm(asStream("value=%C3%28")), UrlEncodedFormError);
+});
+
+test("rejects invalid UTF-8 transport bytes", async () => {
+  await assert.rejects(
+    deserializeUrlEncodedForm(asStream(new Uint8Array([0xc3, 0x28]))),
+    UrlEncodedFormError,
+  );
+});
+
+test("preserves transport failures", async () => {
+  const transportError = new Error("transport failed");
+  await assert.rejects(
+    deserializeUrlEncodedForm(async function* () {
+      throw transportError;
+    }),
+    (error) => error === transportError,
+  );
+});
+
+test("rejects oversized and overpopulated forms", async () => {
+  await assert.rejects(
+    deserializeUrlEncodedForm(asStream(new Uint8Array(urlEncodedFormMaximumBytes + 1))),
+    UrlEncodedFormError,
+  );
+  const fields = Array.from(
+    { length: urlEncodedFormMaximumFields + 1 },
+    (_, index) => `f${index}=v`,
+  ).join("&");
+  await assert.rejects(deserializeUrlEncodedForm(asStream(fields)), UrlEncodedFormError);
+});
+
+test("does not permit prototype pollution", async () => {
+  const result = await deserializeUrlEncodedForm(
+    asStream("__proto__=polluted&constructor=also-safe&csrfToken=valid"),
+  );
+
+  assert.equal(Object.getPrototypeOf(result), null);
+  assert.equal(result.__proto__, "polluted");
+  assert.equal(result.constructor, "also-safe");
+  assert.equal(({} as Record<string, unknown>).polluted, undefined);
+});
+
+test("rejects non-scalar client values and oversized output", async () => {
+  await assert.rejects(collect(serializeUrlEncodedForm({ field: ["value"] })), UrlEncodedFormError);
+  await assert.rejects(
+    collect(serializeUrlEncodedForm({ field: "x".repeat(urlEncodedFormMaximumBytes) })),
+    UrlEncodedFormError,
+  );
+});
+
+function asStream(value: string | Uint8Array) {
+  const bytes = typeof value === "string" ? new TextEncoder().encode(value) : value;
+  return async function* () {
+    yield bytes;
+  };
+}
+
+async function collect(iterable: AsyncIterable<Uint8Array>) {
+  const chunks = new Array<Uint8Array>();
+  let length = 0;
+  for await (const chunk of iterable) {
+    chunks.push(chunk);
+    length += chunk.byteLength;
+  }
+  const result = new Uint8Array(length);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}

--- a/packages/npm/skiffa-lib/src/serialization/urlencoded.ts
+++ b/packages/npm/skiffa-lib/src/serialization/urlencoded.ts
@@ -1,0 +1,95 @@
+export const urlEncodedFormMaximumBytes = 16 * 1024;
+export const urlEncodedFormMaximumFields = 32;
+
+export class UrlEncodedFormError extends TypeError {
+  public readonly name = "UrlEncodedFormError";
+}
+
+export async function* serializeUrlEncodedForm(
+  entity: Record<string, unknown> | Promise<Record<string, unknown>>,
+): AsyncIterable<Uint8Array> {
+  const parameters = new URLSearchParams();
+
+  for (const [name, value] of Object.entries(await entity)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (
+      value !== null &&
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean" &&
+      typeof value !== "bigint"
+    ) {
+      throw new UrlEncodedFormError("URL-encoded form values must be scalar");
+    }
+    parameters.append(name, value === null ? "" : String(value));
+  }
+
+  const encoded = new TextEncoder().encode(parameters.toString());
+  if (encoded.byteLength > urlEncodedFormMaximumBytes) {
+    throw new UrlEncodedFormError("URL-encoded form exceeds the maximum size");
+  }
+  yield encoded;
+}
+
+export async function deserializeUrlEncodedForm(
+  stream: (signal?: AbortSignal) => AsyncIterable<Uint8Array>,
+): Promise<Record<string, string>> {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let byteLength = 0;
+  let encoded = "";
+
+  for await (const chunk of stream()) {
+    byteLength += chunk.byteLength;
+    if (byteLength > urlEncodedFormMaximumBytes) {
+      throw new UrlEncodedFormError("URL-encoded form exceeds the maximum size");
+    }
+    try {
+      encoded += decoder.decode(chunk, { stream: true });
+    } catch {
+      throw new UrlEncodedFormError("URL-encoded form is not valid UTF-8");
+    }
+  }
+  try {
+    encoded += decoder.decode();
+  } catch {
+    throw new UrlEncodedFormError("URL-encoded form is not valid UTF-8");
+  }
+
+  const result = Object.create(null) as Record<string, string>;
+  let fieldCount = 0;
+  for (const field of encoded.split("&")) {
+    if (field === "") {
+      continue;
+    }
+    fieldCount++;
+    if (fieldCount > urlEncodedFormMaximumFields) {
+      throw new UrlEncodedFormError("URL-encoded form has too many fields");
+    }
+
+    const assignmentIndex = field.indexOf("=");
+    const encodedName = assignmentIndex < 0 ? field : field.slice(0, assignmentIndex);
+    const encodedValue = assignmentIndex < 0 ? "" : field.slice(assignmentIndex + 1);
+    const name = decodeFormComponent(encodedName);
+    const value = decodeFormComponent(encodedValue);
+
+    if (Object.hasOwn(result, name)) {
+      throw new UrlEncodedFormError("URL-encoded form contains a duplicate field");
+    }
+    result[name] = value;
+  }
+
+  return result;
+}
+
+function decodeFormComponent(value: string): string {
+  if (/%(?![0-9A-Fa-f]{2})/.test(value)) {
+    throw new UrlEncodedFormError("URL-encoded form contains invalid percent encoding");
+  }
+  try {
+    return decodeURIComponent(value.replaceAll("+", " "));
+  } catch {
+    throw new UrlEncodedFormError("URL-encoded form contains invalid percent encoding");
+  }
+}

--- a/test-package-npm
+++ b/test-package-npm
@@ -11,11 +11,17 @@ ERROR=0
 for F in $(ls fixtures/specifications/*.yaml); do
   echo $(basename $F .yaml)
 
+  REQUEST_TYPES=""
+  if [ "$(basename $F)" = "urlencoded.yaml" ]; then
+    REQUEST_TYPES="--request-types application/x-www-form-urlencoded"
+  fi
+
   node packages/npm/skiffa-generator/bundled/program.js package \
     $F \
     --package-directory generated/npm/$(basename $F .yaml) \
     --package-name $(basename $F .yaml) \
     --package-version "0.0.0" \
+    $REQUEST_TYPES
 
   if [ $? -ne 0 ]; then
     ERROR=1
@@ -36,5 +42,4 @@ for F in $(ls fixtures/specifications/*.yaml); do
 done;
 
 exit $ERROR
-
 


### PR DESCRIPTION
## Summary
- generate typed application/x-www-form-urlencoded client request bodies and server entities
- enforce a 16 KiB / 32-field strict UTF-8 parser with duplicate-field and prototype-pollution defenses
- fix generated Cookie authentication emission
- bump @skiffa/lib to 0.14.6 and @skiffa/generator to 0.14.2

## Verification
- npm test (18/18)
- npm run spelling (215 files, zero issues)
- Prettier check for every changed supported file
- generated client/server round-trip plus duplicate, oversized, malformed, and exact-media-type regressions

## Release order
Publish @skiffa/lib 0.14.6 before @skiffa/generator 0.14.2.